### PR TITLE
Fix $base_url handling to only strip the front part

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,9 @@ include('config.php');
 include('resources/users.php');
 
 $uri = $_SERVER['REQUEST_URI'];
-$local_uri = str_replace($base_url, '', $uri);
+if (strpos($uri, $base_url) === 0) {
+    $local_uri = substr($uri, strlen($base_url));
+}
 $local_uri = explode('?', $local_uri);
 $location = rtrim($local_uri[0], '/');
 


### PR DESCRIPTION
Using str_replace replaces all occurences of the $base_url when parsing
the request URI.
This error is most apparent when $base_url is set to '/', where all
slashes in the URL are removed, and later matches on $location with
anything containing a slash will fail, falling back to the default case.